### PR TITLE
Default admin to false on sync

### DIFF
--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -52,6 +52,7 @@ class WildApricotSync
     el = json
     user = User.create_or_find_by(provider: "wildapricot", uid: el["Id"])
     user.account_administrator = el["IsAccountAdministrator"]
+    user.admin = false # Default to false, overriden by "[nlgroup] wautils" signoff
     user.email = el["Email"]
     user.first_name = el["FirstName"]
     user.last_name = el["LastName"]

--- a/spec/models/wild_apricot_sync_spec.rb
+++ b/spec/models/wild_apricot_sync_spec.rb
@@ -80,5 +80,22 @@ RSpec.describe WildApricotSync do
 
       sync.contacts(json)
     end
+
+    it "removes admin flag when the [nlgroup] wautils is removed" do
+      json = json_file_fixture('waapi_contact_59100437.json')
+
+      sync = WildApricotSync.new
+      sync.contact(json)
+      user = User.find_by uid: 59100437
+      expect(user.admin).to eq true
+
+      # Remove all signoffs, including the `wautils` one
+      idx = json["FieldValues"].find_index {|field| field["FieldName"] == "NL Signoffs and Categories" }
+      json["FieldValues"].delete_at(43)
+
+      sync.contact(json)
+      user = user.reload
+      expect(user.admin).to eq false
+    end
   end
 end


### PR DESCRIPTION
When syncing a user that has had the `[nlgroup] wautils` sign-off removed it was not unsetting the `admin` flag on the user. This resulted in people who should not have access to edit sign offs having that ability.

Thanks to @sudobob for a clear bug report that let me discover and recreate the problem.