### PR TITLE
Formbot OTP

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -32,8 +32,9 @@
 # for integration with WA.
 
 PAGE_TITLE="Nova Labs (development)"
-FORMBOT_URL='https://formbot.nova-labs.org?'
 RAILS_SECRET_KEY_BASE='FIXME'
+FORMBOT_URL='https://formbot.nova-labs.org/'
+FORMBOT_OTP_SECRET="FIXME"
 WA_ACCOUNT='354313'
 WA_SITE_URL='https://makerspace.wildapricot.org/'
 WA_OAUTH_ID='FIXME'

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'omniauth-oauth2'
 
 gem 'faraday'
 gem 'kaminari'
+gem 'rotp'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     requestjs-rails (0.0.9)
       rails (>= 6.0.0)
     rexml (3.2.5)
+    rotp (6.2.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -307,6 +308,7 @@ DEPENDENCIES
   rails (~> 7.0.0)
   redis (~> 4.0)
   requestjs-rails
+  rotp
   rspec-rails (~> 5.0.0)
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
   def fetch_current_user
     begin
       self.current_user = User.find(session[:user_id]) if session[:user_id]
+
+      return nil unless @current_user.uid == session[:user_uid]
+
+      self.current_user
     rescue => e
       Rails.logger.error e
 

--- a/app/controllers/formbot_controller.rb
+++ b/app/controllers/formbot_controller.rb
@@ -11,7 +11,7 @@ class FormbotController < ApplicationController
       redirect_to "#{url}?#{Event.find(params[:event]).uid}", allow_other_host: true
     else
       options = {
-        token: ROTP::TOTP.new(ENV["FORMBOT_OTP_SECRET"]).now,
+        tkn: ROTP::TOTP.new(ENV["FORMBOT_OTP_SECRET"]).now,
         id: Event.find(params[:event]).uid,
       }
       redirect_to "#{url}?#{options.to_query}", allow_other_host: true

--- a/app/controllers/formbot_controller.rb
+++ b/app/controllers/formbot_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FormbotController < ApplicationController
+  skip_before_action :authenticate_user, only: :redirect
+
+  def redirect
+    url = ENV["FORMBOT_URL"]
+
+    # TODO: Once formbot is upgraded delete this conditional
+    if ENV["FORMBOT_USE_LEGACY_FORMAT"]
+      redirect_to "#{url}?#{Event.find(params[:event]).uid}", allow_other_host: true
+    else
+      options = {
+        token: ROTP::TOTP.new(ENV["FORMBOT_OTP_SECRET"]).now,
+        id: Event.find(params[:event]).uid,
+      }
+      redirect_to "#{url}?#{options.to_query}", allow_other_host: true
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,7 @@ class SessionsController < ApplicationController
   def create
     user = User.create_or_update_with_oauth(auth_hash)
     session[:user_id] = user.id
+    session[:user_uid] = user.uid
     session[:oa_credentials_token] = auth_hash.credentials.token
 
     redirect_to :root

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -9,6 +9,6 @@ module EventsHelper
     # So, for displaying the locaiton just show the room. If we don't find a
     # match show the entire location string.
 
-    location[/\((.*)\)/, 1] || location
+    location[/\((.*)\)/, 1] || location rescue location
   end
 end

--- a/app/helpers/formbot_helper.rb
+++ b/app/helpers/formbot_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module FormbotHelper
+  def adhoc_formbot_url
+    "#{ENV["FORMBOT_URL"]}"
+  end
+end

--- a/app/helpers/wild_apricot_helper.rb
+++ b/app/helpers/wild_apricot_helper.rb
@@ -12,8 +12,4 @@ module WildApricotHelper
   def wa_url
     "#{ENV["WA_SITE_URL"]}"
   end
-
-  def formbot_url(event)
-    "#{ENV["FORMBOT_URL"]}#{event.uid}"
-  end
 end

--- a/app/views/shared/_side_nav.html.erb
+++ b/app/views/shared/_side_nav.html.erb
@@ -23,6 +23,11 @@
           Members
         </a>
 
+        <a class="nav-link" href="<%= adhoc_formbot_url %>">
+          <div class="sb-nav-link-icon"><i class="fas fa-asterisk"></i></div>
+          Ad-Hoc Class Form
+        </a>
+
         <% if current_user.signoffer? %>
           <div class="sb-sidenav-menu-heading">Adminstrative</div>
           <a class="nav-link" href="<%= users_path(a: :signoff) %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     get 'contact'
   end
 
+  get 'formbot/:event', to: 'formbot#redirect', as: :formbot
+
   # Admin Section
   get 'admin', to: 'admin/welcome#show'
   namespace :admin do

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -1,0 +1,5 @@
+table_saw:
+  uid: 100
+  start_date: <%= 2.days.from_now %>
+  end_date: <%= 2.days.from_now %>
+  name: "WW_S: Table Saw Sign Off"

--- a/spec/requests/formbot_spec.rb
+++ b/spec/requests/formbot_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Formbots", type: :request do
+  fixtures :events
+
+  describe "GET /formbot/EVENT_ID" do
+    it "adds event id and OTP to url params" do
+      event = events :table_saw
+      get "/formbot/#{event.id}"
+
+      expect(response.code).to eq "302"
+      expect(response.location).to include "id=#{event.uid}"
+      expect(response.location).to match /token=\d{6}/
+    end
+  end
+
+end

--- a/spec/requests/formbot_spec.rb
+++ b/spec/requests/formbot_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Formbots", type: :request do
 
       expect(response.code).to eq "302"
       expect(response.location).to include "id=#{event.uid}"
-      expect(response.location).to match /token=\d{6}/
+      expect(response.location).to match /tkn=\d{6}/
     end
   end
 


### PR DESCRIPTION
[Formbot](https://github.com/Pecacheu/NovaLabs-Instructor-Form) is removing the need for a password! The changes below are to support linking directly to an event with a OTP as a token in the URL that will give an instructor the ability to submit the class to the finance folks.

Ths OTP uses a TOTP approach with a shared secret between Watto and Formbot. For reference I made a short script to test the approach with the [same library](https://github.com/yeojz/otplib) that Formbot will use:

```javascript

// Usage: auth.mjs BASE32SECRET CODE

import { authenticator } from 'otplib';
const secret = process.argv[2];
const token = process.argv[3];
const check = authenticator.check(token, secret);
const verify = authenticator.verify({ token, secret });

console.log('token: ', token, ' check: ', check, ' verify: ', verify);
```

Since the OTP is short lived all links to Formbot will be routed through a new controller that will add `Event#uid` and the newly generated code to the url and redirect to the other host.

For deployment coordination there is a config option set to use the legacy URL format:

```
FORMBOT_USE_LEGACY_FORMAT=true
```

Once the other service is updated that var will be deleted from the environment variables and the wautils service restarted.
