### PR TITLE
Allow user sync with missing field

### DIFF
--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -82,7 +82,13 @@ class WildApricotSync
 
     el["FieldValues"].each do |v|
 
-      field = Field.find_by! system_code: v["SystemCode"]
+      field = Field.find_by system_code: v["SystemCode"]
+
+      if field.nil?
+        Rails.logger.info "Unknown field: #{v} for #{el}"
+        next
+      end
+
       case field.field_type
       when "MultipleChoice"
         if v["Value"]


### PR DESCRIPTION
When fields are added the user sync would fail when trying to set user field values. Most of the time we don't care about the value of those fields (and they'll be updated next sync AFTER the fields are added).

In those cases log there was a problem and keep going with the sync (which is typically because of a webhook)