### PR TITLE
Add check for empty member id list

### DIFF
--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -4,7 +4,11 @@ class BatchUpdateToolsController < ApplicationController
   def show
     @field = Field.signoffs
     @values = @field.allowed_values
-    @contacts = User.where(uid: params["m"]&.split(','))
+    @contacts = if params["m"]
+                  User.where(uid: params["m"]&.split(','))
+                else
+                  []
+                end
   end
 
   def update
@@ -45,5 +49,4 @@ class BatchUpdateToolsController < ApplicationController
     @user = User.find(params[:id])
     render layout: false
   end
-
 end


### PR DESCRIPTION
Fixes #5

There were situations where user records could have a nil uid, while that is never supposed to happen, it did. This checks for a nil value in the `m` param and returns an empty array for the contacts ivar.