### PR TITLE
Add OTP to formbot adhoc link in sidebar

### DIFF
--- a/app/controllers/formbot_controller.rb
+++ b/app/controllers/formbot_controller.rb
@@ -12,8 +12,8 @@ class FormbotController < ApplicationController
     else
       options = {
         tkn: ROTP::TOTP.new(ENV["FORMBOT_OTP_SECRET"]).now,
-        id: Event.find(params[:event]).uid,
       }
+      options[:id] = Event.find(params[:event]).uid unless params[:event] == "adhoc"
       redirect_to "#{url}?#{options.to_query}", allow_other_host: true
     end
   end

--- a/app/helpers/formbot_helper.rb
+++ b/app/helpers/formbot_helper.rb
@@ -2,6 +2,6 @@
 
 module FormbotHelper
   def adhoc_formbot_url
-    "#{ENV["FORMBOT_URL"]}"
+    formbot_url("adhoc")
   end
 end

--- a/spec/requests/formbot_spec.rb
+++ b/spec/requests/formbot_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe "Formbots", type: :request do
     end
   end
 
+  describe "GET /formbot/adhoc" do
+    it "adds OTP to url params but not an ID (to indicate it is adhoc)" do
+      get "/formbot/adhoc"
+
+      expect(response.code).to eq "302"
+      expect(response.location).to_not include "id"
+      expect(response.location).to match /tkn=\d{6}/
+    end
+  end
+
 end


### PR DESCRIPTION
According to @pecacheu:

> Yeah, my form gives the no token error since the token isn't supplied for the ad-hoc link. Just needs a token and no id parameter supplied to go into ad-hoc mode.

So I added a magic `adhoc` param id that will omit the `id` param in the url when redirecting to [formbot](https://github.com/Pecacheu/NovaLabs-Instructor-Form). Makes it easy to change params in the future should we need to be more explicit about these types of events.