### PR TITLE
Make batch sign-off for classes configurable by env

### DIFF
--- a/app/assets/data/classes.json
+++ b/app/assets/data/classes.json
@@ -2,25 +2,24 @@
 	{
 		"class_name": "[class] WW_S: Yellow Tools Sign off",
 		"signoffs_granted": [
+			"[equipment] MXB_WWB_MWY_Grizzly_Bandsaw",
 			"[equipment] WWY_Delta_Spindle/Oscillating Sander",
 			"[equipment] WWY_Dewalt_Scroll Saw",
-			"[equipment] WWY_MXB_Grizzly_Bandsaw",
+			"[equipment]  WWY_Shop Fox_Stationary Sander",
 			"[equipment] WWY_Various_Drill Press",
-			"[equipment] WWB_MXB_Rikon_Bandsaw",
-			"[novapass] WWR_Dewalt_Sliding miter saw",
-			"[equipment] WWY_Shop Fox_Stationary Sander"
+			"[novapass] WWY_Dewalt_Sliding miter saw"
 		]
 	},
 	{
 		"class_name": "[class] MW_S01: Metal Shop Yellow Tools Sign-off",
 		"signoffs_granted": [
-			"[equipment] MWY__Yellow Safety",
 			"[equipment] MWY_Central Forge_Media Blaster",
 			"[equipment] MWY_Central Machinery_1x30 Belt Sander",
 			"[equipment] MWY_Delta_Bench Grinder",
 			"[equipment] MWY_Grizzly_Horizontal Bandsaw",
-			"[equipment] MWY_MXB_Grizzly_Vertical Bandsaw",
+			"[equipment] MWY_Grizzly_Vertical Bandsaw",
 			"[equipment] MWY_Milwaukee_Portaband",
+			"[equipment] MWY_NA_Yellow Safety",
 			"[equipment] MWY_Northern Industrial_Drill Press",
 			"[equipment] MWY_Various_Angle Grinders"
 		]

--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -30,7 +30,12 @@ class BatchUpdateToolsController < ApplicationController
             #It looks like WA can handle duplicate signoffs just fine, so no need to dedup the array
             temp_values = []
             a_class["signoffs_granted"].each do |signoff_name|
-              temp_values << FieldAllowedValue.find_by!(label: signoff_name).uid
+              begin
+                temp_values << FieldAllowedValue.find_by!(label: signoff_name).uid
+              rescue
+                raise "Class tool name not found: #{signoff_name}"
+              end
+
             end
           values.concat(temp_values)
           end

--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -30,7 +30,7 @@ class BatchUpdateToolsController < ApplicationController
             #It looks like WA can handle duplicate signoffs just fine, so no need to dedup the array
             temp_values = []
             a_class["signoffs_granted"].each do |signoff_name|
-              temp_values << FieldAllowedValue.find_by(label: signoff_name).uid
+              temp_values << FieldAllowedValue.find_by!(label: signoff_name).uid
             end
           values.concat(temp_values)
           end

--- a/app/views/batch_update_tools/show.html.erb
+++ b/app/views/batch_update_tools/show.html.erb
@@ -16,11 +16,14 @@
       <label for="signoff_id">Signoff</label>
 
       <select required="" name="field_value" class="form-control" id="signoff_list">
-        <option value="" disabled="" selected="">Select a Sign Off</option>
-        <% @classes.each do |value| %>
-          <option value = "<%= value["class_name"]%>"><%= value["class_name"]%></option>
+        <%- if ENV["SHOW_CLASSES_IN_BATCH_SIGNOFF"] == "true" %>
+          <option value="" disabled="" selected="">Select a Sign Off</option>
+          <% @classes.each do |value| %>
+            <option value = "<%= value["class_name"]%>"><%= value["class_name"]%></option>
+          <% end %>
+          <option value="" disabled="">-----------</option>
         <% end %>
-        <option value="" disabled="">-----------</option>
+
         <% @values.each do |value| %>
           <option value="<%= value.uid %>" <%= "selected" if params[:v]&.to_i == value.uid %>><%= value.label %></option>
         <% end %>


### PR DESCRIPTION
Make it so we can turn off the batch sign-off by a class with an environment variable. 

I also tried to reconcile the list of classes between the staging instance and production instance of WA but was unsuccessful. At the end of this effort I had it working on the prod WA on my local machine, but was getting errors with the queries to lookup the tools for a class by their name. Frustrating when the ugly hacks don't work.