### PR TITLE
Batch update page should only show active users

### DIFF
--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -62,7 +62,7 @@ class BatchUpdateToolsController < ApplicationController
   end
 
   def search
-    @users = User.search(params[:q])
+    @users = User.active_n_enabled.search(params[:q])
     render layout: false
   end
 


### PR DESCRIPTION
One of the wonderful support desk folks notice defunct users were showing up in the search for the signoff page.