### PR TITLE
Sync events starting a fornight past

### DIFF
--- a/app/lib/waapi.rb
+++ b/app/lib/waapi.rb
@@ -77,7 +77,8 @@ class WAAPI
   end
 
   def self.events
-    filter = "$filter=IsUpcoming+eq+True"
+    ten_days_ago = 12.days.ago.strftime("%F")
+    filter = "$filter=StartDate+gt+#{ten_days_ago}"
     async = "$async=false"
     params = [async, filter].join("&")
     Client.new.get(u "accounts/#{config_account_id}/events?#{params}")


### PR DESCRIPTION
When deleting the entire DB and resyncing from WA the past events were not populated. This change goes back in time 12 days from the current day to grab events.

Now I leave you with a short poem:

```
In a maker space not long ago
There were events that needed to flow
To a distant site, far and fast
So they called on Watto, at last

With a flick of a switch and a click of a mouse
The events were synced and the data was roused
From its slumber, to be sent far and wide
With the help of JSON, the task was tide

Now the events are known, by many a soul
Thanks to Watto, the task was whole
And the maker space thrives, with knowledge and skill 
Synced from a fortnight past, with Watto's keen will.
```