### PR TITLE
Sort sign offs by position

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,5 +1,5 @@
 class Field < ApplicationRecord
-  has_many :allowed_values, -> { order(label: :asc) }, class_name: "FieldAllowedValue", dependent: :destroy
+  has_many :allowed_values, -> { order(position: :asc) }, class_name: "FieldAllowedValue", dependent: :destroy
 
   # Boy do I hate using a display name string for a scope
   scope :signoffs, -> { find_by(field_name: "NL Signoffs and Categories") }

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -32,6 +32,8 @@ class WildApricotSync
           value.selected_by_default = v["SelectedByDefault"]
           value.position = v["Position"]
 
+          value.save if value.persisted?
+
           value
         end
 

--- a/lib/tasks/wa.rake
+++ b/lib/tasks/wa.rake
@@ -57,7 +57,7 @@ namespace :wa do
       puts "   #{field.id.to_s.rjust(4)} #{field.field_name}"
       unless field.allowed_values.empty?
         field.allowed_values.each do |v|
-          puts "        - #{v.label}"
+          puts "        - #{v.label} #{v.position}"
         end
       end
     end


### PR DESCRIPTION
Wild Apricot has a position attribute for an allowed value. This was already being stored in the DB, so lets update the sort to use the, well, sort order.

This will allow the org to manage how things are displayed in the sign off pages with the WA admin portal. So more naming things with prefixes just to get things sorted how they want.