### PR TITLE
Update the Fields model to match Wild Apricot's structure

### DIFF
--- a/app/assets/stylesheets/fields.css
+++ b/app/assets/stylesheets/fields.css
@@ -1,8 +1,13 @@
 .badge-default {
   background-color: #6c757d;
 }
+
 .badge-equipment {
-  background-color: #7952b3;
+  background-color: #0d6efd;
+}
+
+.badge-ww {
+  background-color: #6c757d;
 }
 
 .badge-novapass {

--- a/app/controllers/admin/syncs_controller.rb
+++ b/app/controllers/admin/syncs_controller.rb
@@ -14,8 +14,8 @@ class Admin::SyncsController < Admin::BaseController
     contact_fields = WAAPI.contact_fields.json
     sync.contact_fields(contact_fields) do |field|
       log << "   [#{field.id}] #{field.field_name}"
-      unless field.allowed_values.empty?
-        field.allowed_values.each do |v|
+      unless field.filed_allowed_values.empty?
+        field.field_allowed_values.each do |v|
           log << "        #{v.label}"
         end
       end

--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -3,7 +3,7 @@ class BatchUpdateToolsController < ApplicationController
 
   def show
     @field = Field.signoffs
-    @values = @field.allowed_values
+    @values = @field.field_allowed_values
     @contacts = if params["m"]
                   User.where(uid: params["m"]&.split(','))
                 else
@@ -15,7 +15,7 @@ class BatchUpdateToolsController < ApplicationController
 
   def update
     @field = Field.signoffs
-    @values = @field.allowed_values
+    @values = @field.field_allowed_values
     @classes = JSON.parse(File.read("app/assets/data/classes.json"))
 
     @contacts = params["contacts"].uniq

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @signoffs = @user.field_values.where(field:  Field.signoffs).order('label ASC')
+    @signoffs = @user.field_values.signoffs
   end
 
   def update

--- a/app/helpers/fields_helper.rb
+++ b/app/helpers/fields_helper.rb
@@ -56,12 +56,12 @@ module FieldsHelper
 
     when "Choice"
       values.map do |v|
-        v.field.allowed_values.find_by(value: v.value)&.label || "Nil"
+        v.field.field_allowed_values.find_by(value: v.value)&.label || "Nil"
         v.label || "Nil"
       end
     when "MultipleChoice"
       values.map do |v|
-        #v.field.allowed_values.find_by(uid: v.value).label
+        #v.field.field_allowed_values.find_by(uid: v.value).label
         v.label || "Nil"
       end
     else
@@ -71,8 +71,10 @@ module FieldsHelper
   end
 
   def user_field_value_badge(field_value)
-    content_tag :span,
-      field_value.category,
-      class: ["badge", "badge-default", "badge-#{ field_value.category }"]
+    classes = ["badge", "badge-default"]
+    classes = ["badge", "badge-default", "badge-#{field_value.category}".downcase]
+    classes << "badge-novapass" if field_value.novapass?
+
+    content_tag(:span, field_value.category, class: classes)
   end
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,5 +1,6 @@
 class Field < ApplicationRecord
-  has_many :allowed_values, -> { order(position: :asc) }, class_name: "FieldAllowedValue", dependent: :destroy
+  has_many :field_allowed_values, -> { order(position: :asc) }, dependent: :destroy
+  has_many :field_user_values, dependent: :destroy
 
   # Boy do I hate using a display name string for a scope
   scope :signoffs, -> { find_by(field_name: "NL Signoffs and Categories") }

--- a/app/models/field_allowed_value.rb
+++ b/app/models/field_allowed_value.rb
@@ -1,24 +1,33 @@
 class FieldAllowedValue < ApplicationRecord
   belongs_to :field
+  has_many :field_user_values, dependent: :destroy
 
   def name
     @name || begin
-      parse_display_names
-      @name
+    parse_display_names
+    @name
     end
   end
 
   def category
     @category || begin
-      parse_display_names
-      @category
+    parse_display_names
+    @category
+    end
+  end
+
+  def novapass?
+    @novapass || begin
+    parse_display_names
+    @novapass = @tags.include? "NovaPass"
     end
   end
 
   def parse_display_names
     if match = label&.match(/\[(.*)\](.*)/i)
-      @category = match[1]&.strip || "none"
-      @name = match[2]&.gsub("_", " ").strip || "none"
+      @tags = (match[1]&.strip || "none").split("-")
+      @category = @tags.first
+      @name = match[2]&.gsub("_", " ").strip || "Field User Value #{id}"
     end
   end
 end

--- a/app/models/field_user_value.rb
+++ b/app/models/field_user_value.rb
@@ -3,25 +3,15 @@ class FieldUserValue < ApplicationRecord
   belongs_to :field
   belongs_to :field_allowed_value, optional: true
 
+  delegate :category, to: :field_allowed_value
+  delegate :name, to: :field_allowed_value
+  delegate :novapass?, to: :field_allowed_value
+  delegate :label, to: :field_allowed_value, allow_nil: true
+  delegate :position, to: :field_allowed_value
 
-  def name
-    @name || begin
-      parse_display_names
-      @name
-    end
-  end
-
-  def category
-    @category || begin
-      parse_display_names
-      @category
-    end
-  end
-
-  def parse_display_names
-    if match = label&.match(/\[(.*)\](.*)/i)
-      @category = match[1]&.strip || "none"
-      @name = match[2]&.gsub("_", " ").strip || "none"
-    end
-  end
+  scope :signoffs, -> {
+    includes(:field_allowed_value)
+      .where(field: Field.signoffs)
+      .order("field_allowed_values.position ASC")
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
     .where(archived: false)
   }
 
+
   # {"provider"=>"wildapricot",
   #  "uid"=>"59100437",
   #  "info"=>{"email"=>"chris.sexton@nova-labs.org", "name"=>"Christopher Sexton"},
@@ -64,16 +65,16 @@ class User < ApplicationRecord
   end
 
   def signoffer?
-    account_administrator? || admin || field_values.where(label: "[nlgroup] wautils").any?
+    account_administrator? || admin || field_values.includes(:field_allowed_value).where(field_allowed_value: { label: "[nlgroup] wautils" }).any?
   end
 
   # Returns a "truple" of user value, field, and allowed field models
   def signoffs
     #values = field_values.left_joins(:field, :field_allowed_value).where(field: Field.signoffs)
-    values = field_values.where(field: Field.signoffs)
+    values = field_values.signoffs
 
     values.map do |value|
-      allowed = value.field.allowed_values.find_by(uid: value.value)
+      allowed = value.field.field_allowed_values.find_by(uid: value.value)
       [value, value.field, allowed]
     end
   end

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -23,7 +23,7 @@ class WildApricotSync
       field.system_code = el["SystemCode"]
       field.required = nil
 
-      field.allowed_values =
+      field.field_allowed_values =
         el["AllowedValues"].map do |v|
           value = FieldAllowedValue.find_or_initialize_by(uid: v["Id"])
           value.label = v["Label"]
@@ -101,7 +101,7 @@ class WildApricotSync
               system_code: v["SystemCode"]
             )
             fuv.field = field
-            fuv.label = choice_value["Label"]
+            #fuv.label = choice_value["Label"]
             fuv.field_allowed_value = FieldAllowedValue.find_by(uid: choice_value["Id"])
             fuv.save if fuv.persisted?
             field_values << fuv
@@ -114,7 +114,7 @@ class WildApricotSync
           system_code: v["SystemCode"]
         )
         fuv.field = field
-        fuv.label = v.dig("Value", "Label")
+        #fuv.label = v.dig("Value", "Label")
         fuv.field_allowed_value = FieldAllowedValue.find_by(uid: v.dig("Value", "Id"))
         fuv.save if fuv.persisted?
         field_values << fuv

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -226,6 +226,11 @@ class WildApricotSync
 
     r.event = event
     r.user = User.find_by uid: r.contact_uid
+    if r.user == nil
+      contact(WAAPI.contact(r.contact_uid).json) do |user|
+        r.user = user
+      end
+    end
     r.save!
 
     yield(r) if block_given?

--- a/app/views/admin/fields/show.html.erb
+++ b/app/views/admin/fields/show.html.erb
@@ -55,7 +55,7 @@
   <div class="col">
     <h2>Allowed Values</h2>
 
-    <% unless @field.allowed_values.empty? %>
+    <% unless @field.field_allowed_values.empty? %>
       <div class="table-responsive">
         <table class="table table-striped table-sm">
           <thead>
@@ -67,7 +67,7 @@
           </thead>
           <tbody>
 
-            <% @field.allowed_values.each do |v| %>
+            <% @field.field_allowed_values.each do |v| %>
               <tr>
                 <td><%= v.label %></td>
                 <td><%= v.value %></td>

--- a/app/views/admin/user_fields/edit.html.erb
+++ b/app/views/admin/user_fields/edit.html.erb
@@ -11,9 +11,9 @@
   <% if @field.field_type == "String" %>
     <input name="string_value" type="text" value="" maxlength="50" class="typeText">
   <% elsif @field.field_type == "MultipleChoice" %>
-    <% unless @field.allowed_values.empty? %>
+    <% unless @field.field_allowed_values.empty? %>
       <ul>
-        <% @field.allowed_values.each do |v| %>
+        <% @field.field_allowed_values.each do |v| %>
           <li>
             <input type="checkbox" class="form-check-input" name="multiple_choice_values[]id" value="<%= v.uid %>" <%= "checked" if @selected_fields.detect {|f| f.value == v.value } %> >
             <label>
@@ -34,7 +34,7 @@
           </thead>
           <tbody>
 
-            <% @field.allowed_values.each do |v| %>
+            <% @field.field_allowed_values.each do |v| %>
               <tr>
                 <td><%= v.label %></td>
                 <td><%= v.value %></td>

--- a/app/views/user_signoffs/edit.html.erb
+++ b/app/views/user_signoffs/edit.html.erb
@@ -14,11 +14,11 @@
   <% if @field.field_type == "String" %>
     <input name="string_value" type="text" value="" maxlength="50" class="typeText">
   <% elsif @field.field_type == "MultipleChoice" %>
-    <% unless @field.allowed_values.empty? %>
+    <% unless @field.field_allowed_values.empty? %>
       <div class="table-responsive">
         <table class="table">
           <tbody>
-            <% @field.allowed_values.each do |v| %>
+            <% @field.field_allowed_values.each do |v| %>
               <tr>
                 <td scope="row">
                   <input type="checkbox" id="field-<%= v.uid %>" name="multiple_choice_values[]id" class="form-check-input" value="<%= v.uid %>" <%= "checked" if @selected_fields.detect {|f| f.value == v.value } %> >

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -77,12 +77,17 @@
     <h3>Your Sign-offs and Categories</h3>
     <table class="table">
       <tbody>
-        <% current_user.field_values.where(field:  Field.signoffs).order('label ASC').each do |field_value| %>
+        <% current_user.field_values.signoffs.each do |field_value| %>
           <tr>
             <td scope="row">
               <%= user_field_value_badge(field_value) %>
             </td>
-            <td class="w-100"><%= field_value.name %></td>
+            <td class="w-100">
+              <% if field_value.novapass? %>
+                <span class="badge badge-novapass">NovaPass</span>
+              <% end %>
+              <%= field_value.name %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/db/migrate/20221220194413_remove_label_from_field_user_value.rb
+++ b/db/migrate/20221220194413_remove_label_from_field_user_value.rb
@@ -1,0 +1,5 @@
+class RemoveLabelFromFieldUserValue < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :field_user_values, :label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_24_152115) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_20_194413) do
   create_table "credentials", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider"
@@ -79,7 +79,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_24_152115) do
 
   create_table "field_user_values", force: :cascade do |t|
     t.string "value"
-    t.string "label"
     t.string "system_code"
     t.integer "user_id", null: false
     t.integer "field_id"

--- a/lib/tasks/wa.rake
+++ b/lib/tasks/wa.rake
@@ -55,8 +55,8 @@ namespace :wa do
     puts "   Fields:"
     sync.contact_fields(contact_fields) do |field|
       puts "   #{field.id.to_s.rjust(4)} #{field.field_name}"
-      unless field.allowed_values.empty?
-        field.allowed_values.each do |v|
+      unless field.field_allowed_values.empty?
+        field.field_allowed_values.each do |v|
           puts "        - #{v.label} #{v.position}"
         end
       end

--- a/spec/fixtures/field_allowed_values.yml
+++ b/spec/fixtures/field_allowed_values.yml
@@ -15,7 +15,7 @@ field_allowed_value_18:
   selected_by_default: false
   position: 1
   field: signoff_permissions
-field_allowed_value_19:
+field_allowed_value_ww:
   uid: 14917545
   label: WW
   value: '14917545'
@@ -31,7 +31,7 @@ field_allowed_value_20:
   selected_by_default: false
   position: 3
   field: signoff_permissions
-field_allowed_value_21:
+field_allowed_value_3d_fdm:
   uid: 14759088
   label: "[equipment] 3D_FDM Printers"
   value: '14759088'
@@ -47,7 +47,7 @@ field_allowed_value_22:
   selected_by_default: false
   position: 1
   field: signoffs
-field_allowed_value_23:
+field_allowed_value_3d_phrozen:
   uid: 14759090
   label: "[equipment] 3d_Phrozen_LCD SLA"
   value: '14759090'
@@ -367,7 +367,7 @@ field_allowed_value_62:
   selected_by_default: false
   position: 41
   field: signoffs
-field_allowed_value_63:
+field_allowed_value_ww_sawstop:
   uid: 14759130
   label: "[equipment] WW_SawStop_Table Saw"
   value: '14759130'
@@ -455,7 +455,7 @@ field_allowed_value_73:
   selected_by_default: false
   position: 52
   field: signoffs
-field_allowed_value_74:
+field_allowed_value_ww_drill_press:
   uid: 14759141
   label: "[equipment] WWY_Various_Drill Press"
   value: '14759141'
@@ -591,7 +591,7 @@ field_allowed_value_90:
   selected_by_default: false
   position: 69
   field: signoffs
-field_allowed_value_91:
+field_allowed_value_wautils:
   uid: 14759158
   label: "[nlgroup] wautils"
   value: '14759158'

--- a/spec/fixtures/field_user_values.yml
+++ b/spec/fixtures/field_user_values.yml
@@ -1,43 +1,37 @@
 ---
 amy_ww:
   value: '14917545'
-  label: WW
   system_code: custom-13082555
   user: amy
   field: signoff_permissions
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_ww
 amy_3d_fdm_printers:
   value: '14759088'
-  label: '[equipment] 3D_FDM Printers'
   system_code: custom-12971567
   user: amy
   field: signoffs
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_3d_fdm
 amy_3d_sla_printers:
   value: '14759090'
-  label: '[equipment] 3d_Phrozen_LCD SLA'
   system_code: custom-12971567
   user: amy
   field: signoffs
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_3d_phrozen
 amy_ww_sawstop:
   value: '14759130'
-  label: '[equipment] WW_SawStop_Table Saw'
   system_code: custom-12971567
   user: amy
   field: signoffs
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_ww_sawstop
 amy_ww_drillpress:
   value: '14759141'
-  label: '[equipment] WWY_Various_Drill Press'
   system_code: custom-12971567
   user: amy
   field: signoffs
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_ww_drill_press
 amy_wautils:
   value: '14759158'
-  label: '[nlgroup] wautils'
   system_code: custom-12971567
   user: amy
   field: signoffs
-  field_allowed_value_id:
+  field_allowed_value: field_allowed_value_wautils

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  fixtures :users, :fields, :field_allowed_values, :field_user_values
+  fixtures :users, :fields, :field_user_values, :field_allowed_values
 
   it "returns a list of signoffs as a truple (value, field, allowed value)" do
     amy = users(:amy)

--- a/spec/models/wild_apricot_sync_spec.rb
+++ b/spec/models/wild_apricot_sync_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe WildApricotSync do
       sync = WildApricotSync.new
       sync.contact_fields(json)
       expect(json.first["AllowedValues"].length).to eq 4
-      expect(Field.find_by(uid:12971567).allowed_values.count).to eq 4
+      expect(Field.find_by(uid:12971567).field_allowed_values.count).to eq 4
 
       json.first["AllowedValues"].pop
 
       sync2 = WildApricotSync.new
       sync2.contact_fields(json)
       expect(json.first["AllowedValues"].length).to eq 3
-      expect(Field.find_by(uid:12971567).allowed_values.count).to eq 3
+      expect(Field.find_by(uid:12971567).field_allowed_values.count).to eq 3
 
     end
 


### PR DESCRIPTION
Primarily this normalizes the Field User Value to Field Allowed Value, so the field label is pulled out of the Allowed table. This was done because a sync wouldn't update all the labels if someone re-named the allowed value in the WA portal.

In other words: Changing "[equipment] WWY_Various_Drill Press" to "[WW-Y] Drill Press" would not also update the list of user's signoffs. This way we update in one place (the filed_allowed_values table) and all the labels update.

Now event sync will go fetch the missing user to fill in the gaps.
