### PR TITLE
Filter out canceled event registrations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,4 +22,8 @@ class Event < ApplicationRecord
     order(start_date: :asc).where(start_date: (Time.now.midnight - 12.day)..(Time.now.midnight + 1.year))
   }
 
+  def active_registrations
+    event_registrations.where.not(status: "Canceled")
+  end
+
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -77,37 +77,35 @@
       <div class="card-header">
         Registrations
       </div>
-      <% unless @event.event_registrations.empty? %>
+      <% unless @event.active_registrations.empty? %>
         <div class="table-responsive">
           <table class="table align-middle">
             <thead>
               <tr>
                 <th scope="col">#</th>
+                <th scope="col">Registration Type</th>
                 <th scope="col">Name</th>
                 <th scope="col">Email</th>
-                <th scope="col">Fee</th>
-                <th scope="col">Waitlist</th>
                 <th scope="col">Registered At</th>
-                <th scope="col">Registration Type</th>
                 <% if current_user.account_administrator %>
+                  <th scope="col">Waitlist</th>
+                  <th scope="col">Fee</th>
                   <th scope="col">Status</th>
                   <th scope="col"></th>
                 <% end %>
               </tr>
             </thead>
             <tbody>
-              <% @event.event_registrations.each do |reg| %>
+              <% @event.active_registrations.each do |reg| %>
                 <tr>
                   <td><%= reg.id %></td>
-                  <td>
-                    <%= reg.display_name %>
-                  </td>
-                  <td><%= reg.user.email %></td>
-                  <td><%= reg.registration_fee %></td>
-                  <td><%= reg.on_waitlist %></td>
-                  <td><%= reg.registration_date.strftime("%m/%d/%Y") %></td>
                   <td><%= reg.registration_type %></td>
+                  <td><%= reg.display_name %></td>
+                  <td><%= reg.user.email %></td>
+                  <td><%= reg.registration_date.strftime("%m/%d/%Y") %></td>
                   <% if current_user.account_administrator %>
+                    <td><%= reg.on_waitlist %></td>
+                    <td><%= reg.registration_fee %></td>
                     <td><%= reg.status %></td>
                     <td><a href="<%= wa_contact_admin_url reg.user %>">Edit on WA</a></td>
                   <% end %>

--- a/spec/fixtures/event_registrations.yml
+++ b/spec/fixtures/event_registrations.yml
@@ -1,0 +1,33 @@
+doctor_table_saw:
+  contact_uid: 59100437,
+  display_name: "The Doctor"
+  event: table_saw
+  on_waitlist: false
+  paid: true
+  registration_fee: 0
+  registration_type: "Instructor/Host"
+  status: "Free"
+  uid: 100
+  user: doctor
+canceled_amy_table_saw:
+  contact_uid: 59308919
+  display_name: "Pond, Amy"
+  event: table_saw
+  on_waitlist: false
+  paid: true
+  registration_fee: 80
+  registration_type: "RSVP"
+  status: "Canceled"
+  uid: 101
+  user: amy
+rory_table_saw:
+  contact_uid: 59318549
+  display_name: "Pond, Rory"
+  event: table_saw
+  on_waitlist: false
+  paid: true
+  registration_fee: 80
+  registration_type: "RSVP"
+  status: "Paid"
+  uid: 101
+  user: rory

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  fixtures :all
+
+  it "has event registrations" do
+    event = events(:table_saw)
+
+    expect(event.event_registrations.count).to eq 3
+  end
+
+  it "filters cancelled registrations" do
+    event = events(:table_saw)
+
+    expect(event.active_registrations.count).to eq 2
+  end
+end


### PR DESCRIPTION
Fixes #27

Instructors found it confusing to have canceled registrations showing up in the list of attendees with looking at the event detail page. This change filters those out of the list.

Turns out the only way to have an canceled registration is when we get a webhook letting the system know we need to cancel them. Normally the API wouldn't return any in the list when we fetch event details.