### PR TITLE
Add page to edit the badge number

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :require_signoffer, only: [:edit, :update]
   def index
     @users = User.active_n_enabled.page(params[:page])
 
@@ -12,8 +13,40 @@ class UsersController < ApplicationController
     @signoffs = @user.field_values.signoffs
   end
 
-  def update
+  def edit
     @user = User.find(params[:id])
+    @signoffs = @user.field_values.signoffs
+    @signoffs = @user.field_values.signoffs
+  end
+
+  def update
+    #wa_put_data = {
+    #  'Id': this_contact_id,
+    #  'FieldValues': [{
+    #    'SystemCode': gl_equipment_signoff_systemcode,
+    #    'Value': indiv_signoff_ids
+    #  }]
+    #};
+
+    @user = User.find(params[:id])
+    badge_number_field = Field.badge_number
+    system_code = badge_number_field.system_code
+
+    # If we ever need to update more than one we probably wannt refactor this
+    # method to handle multipls field-values in one request.
+    ret = WAAPI.update_contact_field(@user.uid, system_code, params[:badge_number].strip)
+
+    # Fetch the user again because the one returned above doesn't have changes
+    # reflected.
+    ret = WAAPI.contact(@user.uid)
+
+    WildApricotSync.new.contact(ret.json)
+
+    redirect_to user_path(@user), notice: "Updated User"
+  end
+
+  def sync
+    @user = User.find(params[:user_id])
     ret = WAAPI.contact(@user.uid)
 
     if ret.status == 404 # Deleted

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -6,4 +6,5 @@ class Field < ApplicationRecord
   scope :signoffs, -> { find_by(field_name: "NL Signoffs and Categories") }
   scope :permissions, -> { find_by(field_name: "NL Signoff Permissions") }
   scope :reason_for_free_access, -> { find_by(field_name: "Reason for free access") }
+  scope :badge_number, -> { find_by(field_name: "Badge Number") }
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "Edit Member: #{@user.name}" %>
+
+<% content_for :breadcrumbs do %>
+  <%= crumb "Members", to: users_path %>
+  <%= crumb @user.name, to: user_path(@user) %>
+  <%= crumb "Edit", active: true %>
+<% end %>
+
+<hr>
+
+<%= render "shared/flash" %>
+
+<%= form_for @user do |f| %>
+    <div class="mb-3">
+      <label for="badge_number">Badge Number</label>
+  <input name="badge_number" type="text" value="<%= @user.badge_number %>" maxlength="50" class="form-control">
+    </div>
+    <div class="mb-3">
+  <%= f.submit class: "btn btn-primary" %>
+    </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -83,6 +83,9 @@
         <% end %>
         <% if current_user.signoffer? %>
           <li class="list-group-item">
+            <%= link_to "Edit Badge Number", edit_user_path(@user) %>
+          </li>
+          <li class="list-group-item">
             <%= link_to "Edit Sign-offs", edit_user_signoffs_path(@user) %>
           </li>
           <% unless @user.has_google_workspace_account? %>
@@ -91,7 +94,7 @@
             </li>
           <% end %>
           <li class="list-group-item">
-            <%= form_for @user do |f| %>
+            <%= form_for @user, url: user_sync_url(@user) do |f| %>
               <a href="#" onclick="this.closest('form').submit(); return false;">Re-sync from Portal</a>
           <% end %>
           </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,10 @@ Rails.application.routes.draw do
   end
 
   resources :events, only: [:index, :show, :update]
-  resources :users, only: [:index, :show, :update] do
+  resources :users, only: [:index, :show, :edit, :update] do
     resource :signoffs, only: [:edit, :update], controller: "user_signoffs"
     resource :onboarding
+    post 'sync'
   end
   resource :batch_update_tool do
     get 'search'


### PR DESCRIPTION
I debated if we should make a user fields controller and have a generic way to edit any fields (like we do in the admin pages) but opted not to. I think going forward we may need to edit multiple user fields. That will require some refactor for the WAAPI lib, but seems doable.

For not edit user will:

- POST changes to the WA API
- Pull the updated user attributes
- Update the user in the DB
- Redirect to the show user page