### PR TITLE
Add "none" as an option for choice fields

### DIFF
--- a/app/assets/stylesheets/fields.css
+++ b/app/assets/stylesheets/fields.css
@@ -22,6 +22,11 @@
   background-color:  #28a745;
 }
 
+.badge-danger {
+  background-color:  #dc3545;
+}
+
+
 .callout {
     padding: 1.5rem;
     margin-right: 0;

--- a/app/controllers/user_fields_controller.rb
+++ b/app/controllers/user_fields_controller.rb
@@ -12,7 +12,11 @@ class UserFieldsController < ApplicationController
             when "MultipleChoice"
               params[:multiple_choice_values].map{|p| {id: p[:id].to_i}}.as_json
             when "Choice"
-              params[:choice_value][:id] = params[:choice_value][:id].to_i
+              if params[:choice_value][:id].empty?
+                params[:choice_value][:id] = nil
+              else
+                params[:choice_value][:id] = params[:choice_value][:id].to_i
+              end
               params[:choice_value].as_json
             when "String"
               params[:string_value]

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -21,7 +21,7 @@ class WildApricotSync
       field.order = el["Order"]
       field.display_type = nil
       field.system_code = el["SystemCode"]
-      field.required = nil
+      field.required = el["IsRequired"] || false
 
       field.field_allowed_values =
         el["AllowedValues"].map do |v|

--- a/app/views/user_fields/edit.html.erb
+++ b/app/views/user_fields/edit.html.erb
@@ -39,6 +39,17 @@
                       </td>
                     </tr>
                   <% end %>
+                  <% unless @field.required %>
+                    <tr>
+                      <td>
+                        <input id="value-none" type="radio" class="form-check-input" name="choice_value[id]" value="" <%= "checked" if @selected_fields.empty? %> >
+                        <label for="value-none">
+                          <span class="badge badge-danger">None</span>
+                          No option selected
+                        </label>
+                      </td>
+                    </tr>
+                  <% end %>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
For choice fields that are marked not required add an option to the list for "none".

This was a request from the help desk to be able to clear our door settings via watto.