### PR TITLE
Scope user search to active members

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
     @users = User.active_n_enabled.page(params[:page])
 
     if params[:q]
-      @users = User.search(params[:q]).page(params[:page])
+      @users = User.active_n_enabled.search(params[:q]).page(params[:page])
     end
   end
 


### PR DESCRIPTION
Fixes #34

Help desk folks where able to incorrectly assign signoffs to users that were not longer had active memberships. This change will scope that find to the same list that the normal index listing will show.