### PR TITLE
Detect and skip profile picture fields

### DIFF
--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -67,7 +67,8 @@ class BatchUpdateToolsController < ApplicationController
   def search
     @users = User.active_n_enabled.search(params[:q])
     # Allow all users for debugging
-    #@users = User.all.search(params[:q])
+
+    @users = User.all.search(params[:q])
     render layout: false
   end
 

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -119,13 +119,20 @@ class WildApricotSync
         fuv.save if fuv.persisted?
         field_values << fuv
       else
-        fuv = FieldUserValue.find_or_initialize_by(
-          user: user,
-          value:v["Value"],
-          system_code: v["SystemCode"]
-        )
-        fuv.field = field
-        field_values << fuv
+        unless v["Value"].class == Hash
+          fuv = FieldUserValue.find_or_initialize_by(
+            user: user,
+            value:v["Value"],
+            system_code: v["SystemCode"]
+          )
+          fuv.field = field
+          field_values << fuv
+        else
+          puts "Found a field that is a hash, skipping."
+          puts "Value is  #{v["Value"]}"
+          puts "User is  #{user}"
+          puts v
+        end
       end
     end
 


### PR DESCRIPTION
Not profile pic specifically, but any fields that have a hash as the value. Since ruby doesn't wanna cast it to a scalar we just skip. Just so happens this is only profile picture fields right now.

Fixes #42