### PR TITLE
Fix a typo in method name

### DIFF
--- a/app/controllers/admin/syncs_controller.rb
+++ b/app/controllers/admin/syncs_controller.rb
@@ -14,7 +14,7 @@ class Admin::SyncsController < Admin::BaseController
     contact_fields = WAAPI.contact_fields.json
     sync.contact_fields(contact_fields) do |field|
       log << "   [#{field.id}] #{field.field_name}"
-      unless field.filed_allowed_values.empty?
+      unless field.field_allowed_values.empty?
         field.field_allowed_values.each do |v|
           log << "        #{v.label}"
         end


### PR DESCRIPTION
Don't let the dyslexic guy type method names yall.