### PR TITLE
Rename the MMX Bandsaw signoff attribute

### DIFF
--- a/app/assets/data/classes.json
+++ b/app/assets/data/classes.json
@@ -27,7 +27,7 @@
       "[WW-Y] Powermatic Hollow Chisel Mortiser",
       "[WW-Y] Shop Fox Stationary Sander",
       "[MX-B] Basic Tools",
-      "[MX-B] Grizzly Bandsaw"
+      "[MX-B-NovaPass] Grizzly Bandsaw"
     ]
   },
   {
@@ -42,7 +42,7 @@
       "[WW-Y] Powermatic Hollow Chisel Mortiser",
       "[WW-Y] Shop Fox Stationary Sander",
       "[MX-B] Basic Tools",
-      "[MX-B] Grizzly Bandsaw"
+      "[MX-B-NovaPass] Grizzly Bandsaw"
     ]
   },
   {


### PR DESCRIPTION
We are adding the novapass back on the bandsaw so we want to update the attribute to match.