### PR TITLE
Add Sheet Metal Class

### DIFF
--- a/app/assets/data/classes.json
+++ b/app/assets/data/classes.json
@@ -16,6 +16,16 @@
     ]
   },
   {
+    "class_name": "[class] MW_S07: Sheet Metal Tools Sign-off",
+    "class_form_value": "mw_s07",
+    "signoffs_granted": [
+      "[MW-S] Central Forge Throatless Shear",
+      "[MW-S] Chicago Electric Spot Welder",
+      "[MW-S] Woodward Fab Sheet Metal Brake",
+      "[MW-S] Woodward Fab Sheet Metal Shear"
+    ]
+  },
+  {
     "class_name": "[class] MX_S01: Basic Tools Sign-off",
     "class_form_value": "ww_s01",
     "signoffs_granted": [


### PR DESCRIPTION
Mike Weinstein requested on [slack][1]:

> to add a Sheetmetal 'class' sign off for the several tools signoffs
> that come with Sheetmetal

This adds that class with the following tools:

> [MW-S] Central Forge Throatless Shear
> [MW-S] Chicago Electric Spot Welder
> [MW-S] Woodward Fab Sheet Metal Brake
> [MW-S] Woodward Fab Sheet Metal Shear

[1]: https://nova-labs-org.slack.com/archives/CE0T0ULP7/p1741658546392399