### PR TITLE
Display signoff and members on batch update

### DIFF
--- a/app/controllers/batch_update_tools_controller.rb
+++ b/app/controllers/batch_update_tools_controller.rb
@@ -60,8 +60,8 @@ class BatchUpdateToolsController < ApplicationController
       m: params["contacts"].join(","),
       v: params["field_value"],
     }
-    count = @contacts.count
-    redirect_to batch_update_tool_path(opts), notice: "Updated #{count} #{"member".pluralize(count)}"
+    list = @contacts.map{|c| c.first_name }.to_sentence
+    redirect_to batch_update_tool_path(opts), notice: "Updated #{list} on \"#{params["signoff_display_name"]}\""
   end
 
   def search

--- a/app/javascript/controllers/batch_update_tool_controller.js
+++ b/app/javascript/controllers/batch_update_tool_controller.js
@@ -4,6 +4,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [ "searchInput", "search", "contacts", "signoffSelector", "notificationArea", "notificationHeader" ]
 
+  connect() {
+    // The signoff display name isn't plumbed through the request, so when the
+    // page loads update the hidden field so we can get the user feedback in
+    // the flash message for which signoff was applied.
+    const selector = document.getElementById("signoff_list")
+    const selected_value = selector[selector.selectedIndex]
+    document.getElementById("signoff_display_name").value = selected_value.text
+  }
+
   input(event) {
     if (event.target.value.length > 2) {
       console.log("mega ouch", event);
@@ -23,13 +32,14 @@ export default class extends Controller {
   // iff selected option is class, then...
   // pull the signoffs value from the selected option
   // put that data in the notificationArea target to display
-  select(event) {    
+  select(event) {
     console.log("sweet ouch", event)
-    // I can get the selector as a Stimulus target or as the event target. 
-    // I'm not sure which is better SWE. 
+    // I can get the selector as a Stimulus target or as the event target.
+    // I'm not sure which is better SWE.
     // Getting it as the event target makes it easier to extend to other selectors, including accidentally
     const selector = event.target
     const selected_value = selector[selector.selectedIndex]
+    document.getElementById("signoff_display_name").value = selected_value.text
     if (selected_value.hasAttribute("isClass")){
       this.notificationHeaderTarget.style.display="inline"
       const raw_list = selected_value.getAttribute("signoffs")

--- a/app/views/batch_update_tools/show.html.erb
+++ b/app/views/batch_update_tools/show.html.erb
@@ -10,7 +10,7 @@
   <%= form_for @field, url: batch_update_tool_path do |f| %>
     <!-- Prevent implicit submission of the form -->
     <button type="submit" disabled="" style="display: none" aria-hidden="true"></button>
-
+    <%= hidden_field_tag(:signoff_display_name) %>
     <div class="mb-3">
       <label for="signoff_id">Signoff</label>
 


### PR DESCRIPTION
This was a request from Mike Weinstein on [slack][1]

> to add confirmation details (backstory:  when doing repeated
> applications of WAutils to folks and tools and signoffs and stuff and
> possibly during late night sessions, it MIGHT happen that we have lost
> track of whether we actually submitted the action.  Would it be possibly
> to easily confirm what WA utils just completed.  In the example below,
> after running the BL 101 signoff, it would be great if the confirmation
> indicated that it updated the members on BL 101.  But generic so that it
> is for any tool signoff? )

It now looks something like this:

<img width="753" alt="image" src="https://github.com/user-attachments/assets/e363b502-6fe6-4902-b1ad-9f405c704e35" />



[1]: https://nova-labs-org.slack.com/archives/CE0T0ULP7/p1741658546392399