### PR TITLE
Add an events api feed for digital displays

### DIFF
--- a/app/controllers/api/digital_sign_controller.rb
+++ b/app/controllers/api/digital_sign_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Api::DigitalSignController < ApplicationController
+  skip_before_action :authenticate_user
+
+  def events
+    sort = params[:sort] == "desc" ? :desc : :asc
+
+    @events = Event.all
+
+    if params[:q]
+      @events = @events.search(params[:q]).page(params[:page])
+    end
+
+    if params[:past] == "true"
+      @events = @events.past
+    else
+      @events = @events.future
+    end
+
+    @events = @events.page(params[:page]).per(50)
+
+
+    #render json: @events
+    render "api/digital_sign/events", formats: :json
+  end
+end

--- a/app/models/field_allowed_value.rb
+++ b/app/models/field_allowed_value.rb
@@ -1,6 +1,7 @@
 class FieldAllowedValue < ApplicationRecord
   belongs_to :field
   has_many :field_user_values, dependent: :destroy
+  has_many :users, through: :field_user_values
 
   def name
     @name || begin

--- a/app/views/api/digital_sign/events.json.jbuilder
+++ b/app/views/api/digital_sign/events.json.jbuilder
@@ -1,0 +1,55 @@
+json.generated_at Time.current
+
+json.events @events do |event|
+  json.uid event.uid
+  # Use your actual columns here
+  #json.title (event.respond_to?(:title) ? event.title : event.try(:name))
+  json.start_date event.start_date
+  #json.location
+
+  #json.event_type
+  json.registrations_limit event.registrations_limit
+  json.pending_registrations_count event.pending_registrations_count
+  json.confirmed_registrations_count event.confirmed_registrations_count
+  json.active_registrations_count event.active_registrations.count
+  json.name event.name
+  json.event_type event.event_type
+  json.location event.location
+
+
+  json.active_registrations event.active_registrations do |reg|
+    json.registration_type reg.registration_type
+    json.registered_at reg.registration_date
+  end
+
+
+  json.updated_at event.updated_at
+end
+
+
+json.meta do
+  json.page        @events.current_page
+  json.per         @events.limit_value
+  json.total       @events.total_count
+  json.total_pages @events.total_pages
+end
+
+json.links do
+  json.self url_for(request.query_parameters.merge(page: @events.current_page))
+
+  json.next(
+    @events.next_page ? url_for(request.query_parameters.merge(page: @events.next_page)) : nil
+  )
+
+  json.prev(
+    @events.prev_page ? url_for(request.query_parameters.merge(page: @events.prev_page)) : nil
+  )
+end
+
+json.events do
+  json.array! @events do |e|
+    json.extract! e, :id, :event_type, :created_at
+    # add whatever else you want here
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,14 @@ Rails.application.routes.draw do
   get 'formbot/:event', to: 'formbot#redirect', as: :formbot
   get 'signoffs', to: 'signoffs#index'
 
+
+  namespace :api do
+    scope :digital_sign do
+      get :events, to: "digital_sign#events"
+    end
+  end
+
+
   # Admin Section
   get 'admin', to: 'admin/welcome#show'
   namespace :admin do


### PR DESCRIPTION
Exposing events feed for @sklosky-nl and the Digital Signage team.

We need an API feed for the digital signs in the space. Exposing this here because it is readily available and much easier than working with the WA API directly. Plus this lets us easily change the information that is returned and make life easier on the client side.

Consider this a first pass or initial proposal for the format of the data.

This will live at /api/digital_sign/events

The payload will look like this:

    {
      "generated_at": "2026-01-13T15:27:21.802-05:00",
      "events": [
        {
          "uid": 6484326,
          "start_date": "2026-01-12T19:00:00.000-05:00",
          "registrations_limit": null,
          "pending_registrations_count": 0,
          "confirmed_registrations_count": 3,
          "active_registrations_count": 3,
          "name": "3D_O: 3D FDM Open Office Hours (\"OOH\")-Members Only",
          "event_type": "Regular",
          "location": "Nova Labs, 3850 Jermantown Road, Fairfax, VA",
          "active_registrations": [
            {
              "registration_type": "Member",
              "registered_at": "2026-01-07T22:35:42.000-05:00"
            },
            {
              "registration_type": "Member",
              "registered_at": "2026-01-06T13:02:40.000-05:00"
            },
            {
              "registration_type": "Member",
              "registered_at": "2025-12-26T20:53:23.000-05:00"
            }
          ],
          "updated_at": "2026-01-08T09:39:26.926-05:00"
        },
        {
          "uid": 6484153,
          "start_date": "2026-01-12T19:00:00.000-05:00",
          "registrations_limit": 2,
          "pending_registrations_count": 0,
          "confirmed_registrations_count": 0,
          "active_registrations_count": 0,
          "name": "CC_O: CNC Shop OOH - Project help and skill practice",
          "event_type": "Regular",
          "location": "Nova Labs, 3850 Jermantown Rd, Fairfax, VA",
          "active_registrations": [],
          "updated_at": "2026-01-08T09:39:26.929-05:00"
        },
        {
          "uid": 6484127,
          "start_date": "2026-01-15T19:00:00.000-05:00",
          "registrations_limit": 7,
          "pending_registrations_count": 0,
          "confirmed_registrations_count": 0,
          "active_registrations_count": 0,
          "name": "EL_O: Electronics Open Office Hours: Project help & Practice",
          "event_type": "Regular",
          "location": "Nova Labs, 3850 Jermantown Rd, Fairfax, VA",
          "active_registrations": [],
          "updated_at": "2026-01-08T09:39:17.103-05:00"
        }
      ],
      "meta": {
        "page": 1,
        "per": 50,
        "total": 162,
        "total_pages": 4
      },
      "links": {
        "self": "/api/digital_sign/events?page=1",
        "next": "/api/digital_sign/events?page=2",
        "prev": null
      }
    }