### PR TITLE
Add waitlist stats page and show class price on waitlist

### DIFF
--- a/app/controllers/waitlist_stats_controller.rb
+++ b/app/controllers/waitlist_stats_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WaitlistStatsController < ApplicationController
+  def index
+  end
+
+  def stats
+    @stats = WaitlistStats.new.fetch!
+    render layout: false
+  end
+end

--- a/app/lib/waapi.rb
+++ b/app/lib/waapi.rb
@@ -85,7 +85,8 @@ class WAAPI
   end
 
   def self.events
-    ten_days_ago = 12.days.ago.strftime("%F")
+    days_back = ENV.fetch("WA_EVENTS_DAYS_BACK", "12").to_i
+    ten_days_ago = days_back.days.ago.strftime("%F")
     filter = "$filter=StartDate+gt+#{ten_days_ago}"
     async = "$async=false"
     params = [async, filter].join("&")

--- a/app/models/waitlist_stats.rb
+++ b/app/models/waitlist_stats.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+class WaitlistStats
+  attr_reader :registrations, :courses, :loaded_at, :error
+
+  def fetch!
+    raw_regs    = WaitlistRegistration.new.get_registrations
+    raw_courses = WaitlistCourse.new.get_courses
+    @loaded_at     = Time.current
+    @registrations = normalize_registrations(raw_regs)
+    @courses       = raw_courses.reject { |c| c["is_hidden"] == "TRUE" }
+    self
+  rescue => e
+    @error = e.message
+    self
+  end
+
+  def error? = @error.present?
+
+  def total_uncontacted
+    registrations.count { |r| r[:first_contact].empty? && r[:second_contact].empty? }
+  end
+
+  def unique_people
+    registrations.map { |r| r[:name] }.uniq.length
+  end
+
+  # Returns array of hashes, sorted by total waiting (descending).
+  # Each hash: { course:, regs:, contacted:, last_signup_date:, median_wait_days: }
+  # "contacted" = has a value in first_contact OR second_contact
+  def by_course
+    today = Date.today
+    registrations.group_by { |r| r[:course] }
+      .map do |course, rs|
+        contacted = rs.count { |r| r[:first_contact].present? || r[:second_contact].present? }
+        dates     = rs.filter_map { |r| r[:date] }
+        {
+          course:            course,
+          regs:              rs,
+          contacted:         contacted,
+          last_signup_date:  dates.max,
+          median_wait_days:  median(dates.map { |d| (today - d).to_i }),
+        }
+      end
+      .sort_by { |r| -r[:regs].length }
+  end
+
+  def by_membership_level
+    registrations.group_by { |r| r[:membership_level] }
+                 .sort_by  { |_, rs| -rs.length }
+  end
+
+  def by_course_type
+    courses.group_by { |c| c["event_type"].to_s }
+           .sort_by  { |t, _| t == "SIGN_OFF_CLASS" ? "0" : t }
+  end
+
+  def popular_courses(n = 10)
+    registrations.group_by { |r| r[:course] }
+                 .sort_by  { |_, rs| -rs.length }
+                 .first(n)
+  end
+
+  def most_waitlisted_people(n = 10)
+    registrations.group_by { |r| r[:name] }
+                 .sort_by  { |_, rs| -rs.length }
+                 .first(n)
+  end
+
+  def recent_signups(days: 30)
+    cutoff = days.days.ago.to_date
+    registrations.filter_map do |r|
+      r.merge(parsed_date: r[:date]) if r[:date] && r[:date] >= cutoff
+    end.sort_by { |r| r[:parsed_date] }.reverse
+  end
+
+  def orphaned_courses
+    available = courses.map { |c| c["code_and_name"].to_s.strip }.to_set
+    registrations.map { |r| r[:course] }.uniq
+      .reject { |c| available.include?(c) }
+      .map    { |name| { course: name, count: registrations.count { |r| r[:course] == name } } }
+  end
+
+  def empty_waitlists
+    with_waitlist = courses.select { |c| c["is_waitlist_enabled"] == "TRUE" }
+                           .map    { |c| c["code_and_name"].to_s.strip }
+                           .reject(&:empty?)
+    registered = registrations.map { |r| r[:course] }.to_set
+    with_waitlist.reject { |c| registered.include?(c) }
+  end
+
+  private
+
+  def normalize_registrations(raw)
+    raw.map do |r|
+      {
+        name:             r["name"].to_s.strip,
+        course:           r["class"].to_s.strip,
+        slack:            r["slack"].to_s.strip,
+        membership_level: WaitlistStats.normalize_level(r["membership_level"]),
+        date:             parse_sheet_date(r["requested_at"]),
+        first_contact:    r["first_contact"].to_s.strip,
+        second_contact:   r["second_contact"].to_s.strip,
+        watto_id:         r["watto_id"].to_s.strip,
+        wa_id:            r["wa_id"].to_s.strip,
+      }
+    end.reject { |r| r[:name].empty? || r[:course].empty? }
+  end
+
+  def parse_sheet_date(value)
+    Date.strptime(value.to_s.strip, "%m/%d/%Y")
+  rescue ArgumentError, Date::Error
+    nil
+  end
+
+  def median(values)
+    return nil if values.empty?
+    sorted = values.sort
+    mid    = sorted.length / 2
+    sorted.length.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
+  end
+
+  def self.normalize_level(level)
+    return "(unknown)" if level.to_s.strip.empty?
+    level.strip.downcase.start_with?("key") ? "Key" : level.strip
+  end
+end

--- a/app/views/waitlist/index.html.erb
+++ b/app/views/waitlist/index.html.erb
@@ -28,6 +28,7 @@
       <div class="d-flex flex-wrap gap-2">
         <a href="#SIGN_OFF_CLASS" class="btn btn-sm btn-outline-primary">Sign-off Classes</a>
         <a href="#PROJECT_CLASS" class="btn btn-sm btn-outline-primary">Project Classes</a>
+        <%= link_to waitlist_stats_path, class: "btn btn-sm btn-outline-secondary" do %><i class="fas fa-chart-bar me-1" aria-hidden="true"></i> Waitlist Stats<% end %>
         <a href="<%= waitlist_google_sheet_url %>" class="btn btn-sm btn-outline-secondary"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Waitlist Google Sheet</a>
       </div>
     </div>
@@ -72,6 +73,9 @@
         <div class="col-12 col-lg-8 d-flex align-items-center">
           <span class="me-2"><%= shop_badge_from_name(item['code']) %></span>
           <%= item['name'] %>
+          <% if item['class_price'].present? %>
+            <span class="ms-2 text-muted small"><%= item['class_price'] %></span>
+          <% end %>
         </div>
 
         <div class="col-12 col-lg-4 mt-2 mt-lg-0">

--- a/app/views/waitlist_registrations/index.html.erb
+++ b/app/views/waitlist_registrations/index.html.erb
@@ -20,14 +20,14 @@
       <!-- Date Registered -->
       <div class="col-6 col-md-2">
         <strong>Registered:</strong><br>
-        <%= Date.parse(registration["date"]).strftime("%Y-%m-%d") rescue "—" %>
+        <%= Date.parse(registration["requested_at"]).strftime("%Y-%m-%d") rescue "—" %>
       </div>
 
       <!-- Date Contacted -->
       <div class="col-6 col-md-2">
         <strong>Contacted:</strong><br>
-        <% if registration["first_contacted"].present? %>
-          <%= Date.parse(registration["first_contacted"]).strftime("%Y-%m-%d") rescue "—" %>
+        <% if registration["first_contact"].present? %>
+          <%= Date.parse(registration["first_contact"]).strftime("%Y-%m-%d") rescue "—" %>
         <% else %>
           <span class="text-muted">Not yet contacted</span>
         <% end %>

--- a/app/views/waitlist_stats/index.html.erb
+++ b/app/views/waitlist_stats/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Waitlist Stats" %>
+
+<% content_for :breadcrumbs do %>
+  <%= crumb "Waitlist", to: waitlist_index_path %>
+  <%= crumb "Stats", active: true %>
+<% end %>
+
+<turbo-frame id="waitlist-stats" src="<%= stats_waitlist_stats_path %>">
+  <div class="text-center py-5 text-muted">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+    <p class="mt-3">Loading waitlist stats&hellip;</p>
+  </div>
+</turbo-frame>

--- a/app/views/waitlist_stats/stats.html.erb
+++ b/app/views/waitlist_stats/stats.html.erb
@@ -1,0 +1,275 @@
+<turbo-frame id="waitlist-stats">
+
+<% if @stats.error? %>
+  <div class="alert alert-danger">
+    <strong>Failed to load waitlist data:</strong> <%= @stats.error %>
+  </div>
+<% else %>
+
+<%
+  level_badge = ->(level) {
+    case level.to_s.strip
+    when "Key"                        then "bg-danger"
+    when "Associate"                  then "bg-success"
+    when "Weekday"                    then "bg-primary"
+    when "Innovation Center"          then "bg-dark"
+    when "Comp Access"                then "bg-secondary"
+    when "Membership Application"     then "bg-light text-dark border"
+    when /Youth Robotics/             then "bg-warning text-dark"
+    else                                   "bg-secondary"
+    end
+  }
+
+  today = Date.today
+
+  days_ago = ->(date) {
+    return nil unless date
+    n = (today - date).to_i
+    n == 0 ? "today" : n == 1 ? "1d ago" : "#{n}d ago"
+  }
+
+  days_ago_class = ->(date) {
+    return "text-muted" unless date
+    n = (today - date).to_i
+    if n <= 7    then "text-success fw-semibold"
+    elsif n <= 30 then "text-warning"
+    else              "text-danger"
+    end
+  }
+%>
+
+<%# ── Summary bar ──────────────────────────────────────────────────────────── %>
+<div class="row g-3 mb-4">
+  <div class="col-6 col-md-3">
+    <div class="card text-center h-100">
+      <div class="card-body">
+        <div class="display-6"><%= @stats.registrations.length %></div>
+        <div class="text-muted small">Total registrations</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card text-center h-100">
+      <div class="card-body">
+        <div class="display-6"><%= @stats.unique_people %></div>
+        <div class="text-muted small">People waiting</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card text-center h-100">
+      <div class="card-body">
+        <div class="display-6 text-warning"><%= @stats.total_uncontacted %></div>
+        <div class="text-muted small">Not yet contacted</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card text-center h-100">
+      <div class="card-body">
+        <div class="display-6"><%= @stats.courses.length %></div>
+        <div class="text-muted small">Available courses</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%# ── Classes to schedule ──────────────────────────────────────────────────── %>
+<div class="card mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <strong>Classes to Schedule</strong>
+    <span class="text-muted small">sorted by total waiting</span>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-sm table-hover mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Course</th>
+          <th class="text-end">Waiting</th>
+          <th class="text-end">Contacted</th>
+          <th class="text-end">Last Signup</th>
+          <th class="text-end">Median Wait</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @stats.by_course.each do |row| %>
+          <tr>
+            <td><%= shop_badge_from_name(row[:course]) %> <%= row[:course] %></td>
+            <td class="text-end fw-semibold"><%= row[:regs].length %></td>
+            <td class="text-end <%= row[:contacted] > 0 ? "text-success" : "text-muted" %>">
+              <%= row[:contacted] > 0 ? row[:contacted] : "—" %>
+            </td>
+            <td class="text-end <%= days_ago_class.(row[:last_signup_date]) %>">
+              <%= days_ago.(row[:last_signup_date]) || "—" %>
+            </td>
+            <td class="text-end text-muted">
+              <% if (m = row[:median_wait_days]) %>
+                <% if m < 30    then %><%= m.round %>d
+                <% elsif m < 90 then %><%= (m / 7.0).round %>w
+                <% else              %><%= (m / 30.0).round %>mo
+                <% end %>
+              <% else %>—<% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%# ── Most popular courses ─────────────────────────────────────────────────── %>
+<div class="card mb-4">
+  <div class="card-header"><strong>Most Popular Courses</strong></div>
+  <div class="table-responsive">
+    <table class="table table-sm mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>#</th>
+          <th>Course</th>
+          <th class="text-end">Waiting</th>
+          <th>Membership levels</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @stats.popular_courses(10).each_with_index do |(course, rs), i| %>
+          <tr>
+            <td class="text-muted"><%= i + 1 %></td>
+            <td><%= shop_badge_from_name(course) %> <%= course %></td>
+            <td class="text-end"><%= rs.length %></td>
+            <td>
+              <% rs.group_by { |r| r[:membership_level] }
+                   .sort_by { |_, xs| -xs.length }
+                   .each do |lvl, xs| %>
+                <span class="badge <%= level_badge.(lvl) %> me-1"><%= xs.length %> <%= lvl %></span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="row g-4 mb-4">
+
+  <%# ── Membership level breakdown + orphaned courses ─────────────────────── %>
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header"><strong>Registrations by Membership Level</strong></div>
+      <div class="table-responsive">
+        <table class="table table-sm mb-0">
+          <thead class="table-light">
+            <tr><th>Level</th><th class="text-end">Count</th><th class="text-end">%</th></tr>
+          </thead>
+          <tbody>
+            <% @stats.by_membership_level.each do |level, rs| %>
+              <tr>
+                <td><span class="badge <%= level_badge.(level) %>"><%= level %></span></td>
+                <td class="text-end"><%= rs.length %></td>
+                <td class="text-end text-muted"><%= (rs.length * 100.0 / @stats.registrations.length).round(1) %>%</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <% orphaned = @stats.orphaned_courses %>
+    <% unless orphaned.empty? %>
+      <div class="card border-warning">
+        <div class="card-header bg-warning text-dark"><strong>Waitlisted Courses No Longer Available</strong></div>
+        <div class="table-responsive">
+          <table class="table table-sm mb-0">
+            <thead class="table-light">
+              <tr><th>Course</th><th class="text-end">Still waiting</th></tr>
+            </thead>
+            <tbody>
+              <% orphaned.each do |row| %>
+                <tr>
+                  <td><%= row[:course] %></td>
+                  <td class="text-end "><%= row[:count] %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <%# ── Members on the most waitlists ───────────────────────────────────────── %>
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header"><strong>Most Waitlists per Person</strong></div>
+      <div class="table-responsive">
+        <table class="table table-sm mb-0">
+          <thead class="table-light">
+            <tr><th>#</th><th>Name</th><th class="text-end">Courses</th></tr>
+          </thead>
+          <tbody>
+            <% @stats.most_waitlisted_people(10).each_with_index do |(name, rs), i| %>
+              <% collapse_id = "person-courses-#{i}" %>
+              <tr>
+                <td class="text-muted"><%= i + 1 %></td>
+                <td>
+                  <a class="text-body text-decoration-none"
+                     role="button"
+                     data-bs-toggle="collapse"
+                     href="#<%= collapse_id %>"
+                     aria-expanded="false">
+                    <%= name %>
+                    <i class="fas fa-chevron-down ms-1 small text-muted"></i>
+                  </a>
+                  <div class="collapse text-muted small mt-1" id="<%= collapse_id %>">
+                    <% rs.each do |r| %>
+                      <div><%= shop_badge_from_name(r[:course]) %> <%= r[:course] %></div>
+                    <% end %>
+                  </div>
+                </td>
+                <td class="text-end"><%= rs.length %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<%# ── Recent signups ───────────────────────────────────────────────────────── %>
+<% recent = @stats.recent_signups(days: 30) %>
+<% unless recent.empty? %>
+  <div class="card mb-4">
+    <div class="card-header"><strong>Recent Signups — Last 30 Days</strong> <span class="text-muted small ms-2"><%= recent.length %> signups</span></div>
+    <div class="table-responsive">
+      <table class="table table-sm mb-0">
+        <thead class="table-light">
+          <tr><th>Date</th><th>Name</th><th>Course</th><th>Level</th></tr>
+        </thead>
+        <tbody>
+          <% recent.each do |r| %>
+            <tr>
+              <td class="text-muted"><%= r[:date]&.strftime("%-m/%-d/%Y") %></td>
+              <td><%= r[:name] %></td>
+              <td><%= shop_badge_from_name(r[:course]) %> <%= r[:course] %></td>
+              <td>
+                <% if r[:membership_level].present? %>
+                  <span class="badge <%= level_badge.(r[:membership_level]) %>"><%= r[:membership_level] %></span>
+                <% else %>
+                  <span class="text-muted">—</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>
+
+
+<p class="text-muted small text-end">Loaded at <%= @stats.loaded_at&.strftime("%H:%M:%S") %></p>
+
+<% end %>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   resources :events, only: [:index, :show, :update]
   resources :waitlist, only: [:index]
   resources :waitlist_registrations, only: [:index, :create, :new]
+  resources :waitlist_stats, only: [:index] do
+    get :stats, on: :collection
+  end
 
   resources :users, only: [:index, :show, :edit, :update] do
     resource :onboarding


### PR DESCRIPTION
Walter asked if we could show the price of a class on the waitlist page so members know what they're signing up for before joining a queue. Rather than hardcoding prices, we're managing them in the `available_classes` Google Sheet alongside the other class metadata, so the events team controls it without a deploy.

<img width="2278" height="1016" alt="CleanShot 2026-04-13 at 10 37 51@2x" src="https://github.com/user-attachments/assets/bbf66028-88e3-41ac-83cb-24e4b453ce33" />


The bigger addition is a new `/waitlist_stats` page for the events team. It pulls live data from the waitlist Google Sheet and breaks down what's happening across the waitlist: which classes have the most people waiting, how long people have been waiting (median age), whether anyone has been contacted, and which membership levels are signing up. The page loads async so the initial render is instant and the data fetches in the background.

<img width="1099" height="686" alt="image" src="https://github.com/user-attachments/assets/0ef3244b-6d42-4381-968a-53aa74c0b8ac" />


The stats are specifically meant to help the events team figure out which classes to schedule next, and to surface problems like classes that were removed from the available list but still have people waiting in the queue.