### PR TITLE
Add sorting and filters to the waitlist stats

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -1,3 +1,15 @@
+/* Sortable / filterable table */
+.filter-row th {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.filter-row input[type="search"] {
+  font-weight: normal;
+  font-size: 0.8rem;
+  min-width: 0;
+}
+
 /* Sortable table column headers */
 .sortable-col {
   cursor: pointer;

--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -1,0 +1,22 @@
+/* Sortable table column headers */
+.sortable-col {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.sortable-col::after {
+  content: " ⇅";
+  opacity: 0.3;
+  font-size: 0.75em;
+}
+
+.sortable-col.sort-asc::after {
+  content: " ▲";
+  opacity: 1;
+}
+
+.sortable-col.sort-desc::after {
+  content: " ▼";
+  opacity: 1;
+}

--- a/app/javascript/controllers/sortable_table_controller.js
+++ b/app/javascript/controllers/sortable_table_controller.js
@@ -3,8 +3,13 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="sortable-table"
 // Add data-sort-col="N" (0-indexed) to each <th> you want sortable.
 // Add data-sort-value="..." to each <td> for the raw sort key.
+// Add data-action="input->sortable-table#filterRows" data-sort-col="N" to filter inputs.
 export default class extends Controller {
+  static targets = ["filterRow"]
+
   connect() {
+    this.filters = {}
+
     // Pick up any pre-sorted column indicated in the markup
     const activeHeader = this.element.querySelector("thead th.sort-asc, thead th.sort-desc")
     if (activeHeader) {
@@ -27,11 +32,10 @@ export default class extends Controller {
       this.sortAsc = true
     }
 
-    this.element.querySelectorAll("thead th").forEach((h, i) => {
+    this.element.querySelectorAll("thead th[data-sort-col]").forEach(h => {
+      const hCol = parseInt(h.dataset.sortCol)
       h.classList.remove("sort-asc", "sort-desc")
-      if (i === col) {
-        h.classList.add(this.sortAsc ? "sort-asc" : "sort-desc")
-      }
+      if (hCol === col) h.classList.add(this.sortAsc ? "sort-asc" : "sort-desc")
     })
 
     const tbody = this.element.querySelector("tbody")
@@ -52,5 +56,44 @@ export default class extends Controller {
     })
 
     rows.forEach(row => tbody.appendChild(row))
+    this._applyFilters()
+  }
+
+  toggleFilter(event) {
+    event.preventDefault()
+    const row = this.filterRowTarget
+    const hidden = row.classList.toggle("d-none")
+    if (hidden) {
+      row.querySelectorAll("input").forEach(i => { i.value = "" })
+      this.filters = {}
+      this._applyFilters()
+    } else {
+      row.querySelector("input")?.focus()
+    }
+  }
+
+  filterRows(event) {
+    const col = parseInt(event.currentTarget.dataset.sortCol)
+    const val = event.currentTarget.value.trim().toLowerCase()
+
+    if (val) {
+      this.filters[col] = val
+    } else {
+      delete this.filters[col]
+    }
+
+    this._applyFilters()
+  }
+
+  _applyFilters() {
+    const activeFilters = Object.entries(this.filters)
+    this.element.querySelector("tbody").querySelectorAll("tr").forEach(row => {
+      const tds = row.querySelectorAll("td")
+      const visible = activeFilters.every(([col, term]) => {
+        const td = tds[parseInt(col)]
+        return td && td.textContent.trim().toLowerCase().includes(term)
+      })
+      row.style.display = visible ? "" : "none"
+    })
   }
 }

--- a/app/javascript/controllers/sortable_table_controller.js
+++ b/app/javascript/controllers/sortable_table_controller.js
@@ -1,0 +1,56 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="sortable-table"
+// Add data-sort-col="N" (0-indexed) to each <th> you want sortable.
+// Add data-sort-value="..." to each <td> for the raw sort key.
+export default class extends Controller {
+  connect() {
+    // Pick up any pre-sorted column indicated in the markup
+    const activeHeader = this.element.querySelector("thead th.sort-asc, thead th.sort-desc")
+    if (activeHeader) {
+      this.sortCol = parseInt(activeHeader.dataset.sortCol)
+      this.sortAsc = activeHeader.classList.contains("sort-asc")
+    } else {
+      this.sortCol = null
+      this.sortAsc = true
+    }
+  }
+
+  sort(event) {
+    const th = event.currentTarget
+    const col = parseInt(th.dataset.sortCol)
+
+    if (this.sortCol === col) {
+      this.sortAsc = !this.sortAsc
+    } else {
+      this.sortCol = col
+      this.sortAsc = true
+    }
+
+    this.element.querySelectorAll("thead th").forEach((h, i) => {
+      h.classList.remove("sort-asc", "sort-desc")
+      if (i === col) {
+        h.classList.add(this.sortAsc ? "sort-asc" : "sort-desc")
+      }
+    })
+
+    const tbody = this.element.querySelector("tbody")
+    const rows = Array.from(tbody.querySelectorAll("tr"))
+
+    rows.sort((a, b) => {
+      const aRaw = a.querySelectorAll("td")[col]?.dataset.sortValue ?? ""
+      const bRaw = b.querySelectorAll("td")[col]?.dataset.sortValue ?? ""
+
+      const aNum = parseFloat(aRaw)
+      const bNum = parseFloat(bRaw)
+
+      const cmp = (!isNaN(aNum) && !isNaN(bNum))
+        ? aNum - bNum
+        : aRaw.localeCompare(bRaw)
+
+      return this.sortAsc ? cmp : -cmp
+    })
+
+    rows.forEach(row => tbody.appendChild(row))
+  }
+}

--- a/app/models/waitlist_stats.rb
+++ b/app/models/waitlist_stats.rb
@@ -29,13 +29,21 @@ class WaitlistStats
   # Each hash: { course:, regs:, contacted:, last_signup_date:, median_wait_days: }
   # "contacted" = has a value in first_contact OR second_contact
   def by_course
-    today = Date.today
+    today        = Date.today
+    course_types = courses.each_with_object({}) do |c, h|
+      h[c["code_and_name"].to_s.strip] = c["event_type"].to_s.strip
+    end
+    last_offered = last_offered_lookup
+
     registrations.group_by { |r| r[:course] }
       .map do |course, rs|
         contacted = rs.count { |r| r[:first_contact].present? || r[:second_contact].present? }
         dates     = rs.filter_map { |r| r[:date] }
+        code      = course.split(":").first.strip.downcase
         {
           course:            course,
+          course_type:       course_types[course],
+          last_offered:      last_offered[code]&.to_date,
           regs:              rs,
           contacted:         contacted,
           last_signup_date:  dates.max,
@@ -111,6 +119,14 @@ class WaitlistStats
     Date.strptime(value.to_s.strip, "%m/%d/%Y")
   rescue ArgumentError, Date::Error
     nil
+  end
+
+  def last_offered_lookup
+    Event.where(start_date: ..Time.current)
+         .each_with_object({}) do |e, h|
+           code = e.name.strip.split(":").first.strip.downcase
+           h[code] = [h[code], e.start_date].compact.max
+         end
   end
 
   def median(values)

--- a/app/views/waitlist/index.html.erb
+++ b/app/views/waitlist/index.html.erb
@@ -28,9 +28,7 @@
       <div class="d-flex flex-wrap gap-2">
         <a href="#SIGN_OFF_CLASS" class="btn btn-sm btn-outline-primary">Sign-off Classes</a>
         <a href="#PROJECT_CLASS" class="btn btn-sm btn-outline-primary">Project Classes</a>
-        <!--
         <%= link_to waitlist_stats_path, class: "btn btn-sm btn-outline-secondary" do %><i class="fas fa-chart-bar me-1" aria-hidden="true"></i> Waitlist Stats<% end %>
-        -->
         <a href="<%= waitlist_google_sheet_url %>" class="btn btn-sm btn-outline-secondary"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Waitlist Google Sheet</a>
       </div>
     </div>

--- a/app/views/waitlist_stats/stats.html.erb
+++ b/app/views/waitlist_stats/stats.html.erb
@@ -78,31 +78,31 @@
 <div class="card mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">
     <strong>Classes to Schedule</strong>
-    <span class="text-muted small">sorted by total waiting</span>
+    <span class="text-muted small">click a column to sort</span>
   </div>
   <div class="table-responsive">
-    <table class="table table-sm table-hover mb-0">
+    <table class="table table-sm table-hover mb-0 sortable-table" data-controller="sortable-table">
       <thead class="table-light">
         <tr>
-          <th>Course</th>
-          <th class="text-end">Waiting</th>
-          <th class="text-end">Contacted</th>
-          <th class="text-end">Last Signup</th>
-          <th class="text-end">Median Wait</th>
+          <th class="sortable-col" data-action="click->sortable-table#sort" data-sort-col="0">Course</th>
+          <th class="sortable-col text-end sort-desc" data-action="click->sortable-table#sort" data-sort-col="1">Waiting</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="2">Contacted</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="3">Last Signup</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="4">Median Wait</th>
         </tr>
       </thead>
       <tbody>
         <% @stats.by_course.each do |row| %>
           <tr>
-            <td><%= shop_badge_from_name(row[:course]) %> <%= row[:course] %></td>
-            <td class="text-end fw-semibold"><%= row[:regs].length %></td>
-            <td class="text-end <%= row[:contacted] > 0 ? "text-success" : "text-muted" %>">
+            <td data-sort-value="<%= row[:course] %>"><%= shop_badge_from_name(row[:course]) %> <%= row[:course] %></td>
+            <td class="text-end fw-semibold" data-sort-value="<%= row[:regs].length %>"><%= row[:regs].length %></td>
+            <td class="text-end <%= row[:contacted] > 0 ? "text-success" : "text-muted" %>" data-sort-value="<%= row[:contacted] %>">
               <%= row[:contacted] > 0 ? row[:contacted] : "—" %>
             </td>
-            <td class="text-end <%= days_ago_class.(row[:last_signup_date]) %>">
+            <td class="text-end <%= days_ago_class.(row[:last_signup_date]) %>" data-sort-value="<%= row[:last_signup_date] ? (today - row[:last_signup_date]).to_i : 99999 %>">
               <%= days_ago.(row[:last_signup_date]) || "—" %>
             </td>
-            <td class="text-end text-muted">
+            <td class="text-end text-muted" data-sort-value="<%= row[:median_wait_days] || 99999 %>">
               <% if (m = row[:median_wait_days]) %>
                 <% if m < 30    then %><%= m.round %>d
                 <% elsif m < 90 then %><%= (m / 7.0).round %>w

--- a/app/views/waitlist_stats/stats.html.erb
+++ b/app/views/waitlist_stats/stats.html.erb
@@ -75,13 +75,16 @@
 </div>
 
 <%# ── Classes to schedule ──────────────────────────────────────────────────── %>
-<div class="card mb-4">
+<div class="card mb-4" data-controller="sortable-table">
   <div class="card-header d-flex justify-content-between align-items-center">
     <strong>Classes to Schedule</strong>
-    <span class="text-muted small">click a column to sort</span>
+    <span class="text-muted small">
+      click a column to sort &middot;
+      <a href="#" data-action="click->sortable-table#toggleFilter">filter</a>
+    </span>
   </div>
   <div class="table-responsive">
-    <table class="table table-sm table-hover mb-0 sortable-table" data-controller="sortable-table">
+    <table class="table table-sm table-hover mb-0">
       <thead class="table-light">
         <tr>
           <th class="sortable-col" data-action="click->sortable-table#sort" data-sort-col="0">Course</th>
@@ -89,6 +92,13 @@
           <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="2">Contacted</th>
           <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="3">Last Signup</th>
           <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="4">Median Wait</th>
+        </tr>
+        <tr class="filter-row d-none" data-sortable-table-target="filterRow">
+          <th><input type="search" class="form-control form-control-sm" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="0"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="1"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="2"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="3"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="4"></th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/waitlist_stats/stats.html.erb
+++ b/app/views/waitlist_stats/stats.html.erb
@@ -36,6 +36,26 @@
     else              "text-danger"
     end
   }
+
+  time_ago = ->(date) {
+    return nil unless date
+    n = (today - date).to_i
+    if    n == 0        then "today"
+    elsif n < 7         then "#{n}d ago"
+    elsif n < 60        then "#{(n / 7.0).round}w ago"
+    elsif n < 365       then "#{(n / 30.0).round}mo ago"
+    else                     "#{(n / 365.0).round(1)}y ago"
+    end
+  }
+
+  time_ago_class = ->(date) {
+    return "text-muted" unless date
+    n = (today - date).to_i
+    if    n < 90  then "text-success"
+    elsif n < 180 then "text-warning"
+    else               "text-danger"
+    end
+  }
 %>
 
 <%# ── Summary bar ──────────────────────────────────────────────────────────── %>
@@ -88,23 +108,46 @@
       <thead class="table-light">
         <tr>
           <th class="sortable-col" data-action="click->sortable-table#sort" data-sort-col="0">Course</th>
-          <th class="sortable-col text-end sort-desc" data-action="click->sortable-table#sort" data-sort-col="1">Waiting</th>
-          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="2">Contacted</th>
-          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="3">Last Signup</th>
-          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="4">Median Wait</th>
+          <th class="sortable-col" data-action="click->sortable-table#sort" data-sort-col="1">Type</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="2">Last Offered</th>
+          <th class="sortable-col text-end sort-desc" data-action="click->sortable-table#sort" data-sort-col="3">Waiting</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="4">Contacted</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="5">Last Signup</th>
+          <th class="sortable-col text-end" data-action="click->sortable-table#sort" data-sort-col="6">Median Wait</th>
         </tr>
         <tr class="filter-row d-none" data-sortable-table-target="filterRow">
           <th><input type="search" class="form-control form-control-sm" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="0"></th>
-          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="1"></th>
+          <th><input type="search" class="form-control form-control-sm" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="1"></th>
           <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="2"></th>
           <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="3"></th>
           <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="4"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="5"></th>
+          <th><input type="search" class="form-control form-control-sm text-end" placeholder="filter…" data-action="input->sortable-table#filterRows" data-sort-col="6"></th>
         </tr>
       </thead>
       <tbody>
         <% @stats.by_course.each do |row| %>
+          <%
+            type_label, type_class = case row[:course_type]
+            when "SIGN_OFF_CLASS"  then ["Sign-off", "bg-info text-dark"]
+            when "PROJECT_CLASS"   then ["Project",  "bg-warning text-dark"]
+            else                        [nil,         nil]
+            end
+          %>
           <tr>
             <td data-sort-value="<%= row[:course] %>"><%= shop_badge_from_name(row[:course]) %> <%= row[:course] %></td>
+            <td data-sort-value="<%= type_label || row[:course_type] %>">
+              <% if type_label %>
+                <span class="badge <%= type_class %>"><%= type_label %></span>
+              <% elsif row[:course_type].present? %>
+                <span class="badge bg-secondary"><%= row[:course_type] %></span>
+              <% else %>
+                <span class="text-muted">—</span>
+              <% end %>
+            </td>
+            <td class="text-end <%= time_ago_class.(row[:last_offered]) %>" data-sort-value="<%= row[:last_offered] ? (today - row[:last_offered]).to_i : 99999 %>">
+              <%= time_ago.(row[:last_offered]) || "—" %>
+            </td>
             <td class="text-end fw-semibold" data-sort-value="<%= row[:regs].length %>"><%= row[:regs].length %></td>
             <td class="text-end <%= row[:contacted] > 0 ? "text-success" : "text-muted" %>" data-sort-value="<%= row[:contacted] %>">
               <%= row[:contacted] > 0 ? row[:contacted] : "—" %>


### PR DESCRIPTION
Goe a few requests from Walter:

> Walter Schostak  [6:30 PM]
> I think this is really great. a few small (and one not so small) things that would make it even more useful:
>
> - ability to sort by each column (this would then make it so i can take a screenshot to get the table i sent in the woodshop cannel)
> - filter by column (which is basically enables same thing)
> - filter by signoff vs project 
> - this would be a more complicated integration but a "last offered on" would be pretty slick

A note about adding last offered date:

Walter asked for a way to see when a class was last run so event coordinators can prioritize scheduling — courses with a long gap since the last offering and a big waitlist should jump to the top of the queue.

The "Last Offered" date is looked up from the local Event table by matching on the course code prefix (the part before the colon, e.g.  "WW_P20"). Full name matching was tried first but only hit ~40% of courses because capitalization drifts between the Google Sheet and the event system. Code-prefix matching covers ~85% and is stable.  The lookup builds a code→most-recent-start-date hash in one query so by_course doesn't hit the DB per row.

Also added a Type column (Sign-off / Project) from the sheet's event_type field, and a time_ago helper that scales from days to weeks to months to years so old dates don't show as "300d ago".
