### PR TITLE
Add tags and image_url to digital sign events API

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,6 +12,26 @@ module EventsHelper
     location[/\((.*)\)/, 1] || location rescue location
   end
 
+  def google_calendar_url(event)
+    if event.start_time_specified?
+      start_str = event.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
+      end_str   = (event.end_date || event.start_date + 1.hour).utc.strftime("%Y%m%dT%H%M%SZ")
+    else
+      start_str = event.start_date.strftime("%Y%m%d")
+      end_str   = (event.end_date || event.start_date + 1.day).strftime("%Y%m%d")
+    end
+
+    params = {
+      action:   "TEMPLATE",
+      text:     event.name,
+      dates:    "#{start_str}/#{end_str}",
+      details:  event.description,
+      location: event.location
+    }.compact
+
+    "https://calendar.google.com/calendar/render?#{params.to_query}"
+  end
+
   def shop_badge_from_name(name)
     return "" unless name
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  serialize :tags, JSON
+
   has_many :event_registrations, dependent: :destroy
   has_many :instructor_registrations, -> { where("registration_type LIKE ?", "%Instructor%") }, class_name: "EventRegistration"
 

--- a/app/models/wild_apricot_sync.rb
+++ b/app/models/wild_apricot_sync.rb
@@ -226,6 +226,9 @@ class WildApricotSync
     e.start_time_specified = json["StartTimeSpecified"] #=>true,
     e.end_time_specified = json["EndTimeSpecified"] #=>true,
     e.name = json["Name"] #=>"Test Event in the Past"}
+    e.tags = json["Tags"] || []
+    html = json.dig("Details", "DescriptionHtml")
+    e.image_url = extract_image_url(html) if html.present?
     e.save!
 
     yield(e) if block_given?
@@ -263,5 +266,17 @@ class WildApricotSync
     r.save!
 
     yield(r) if block_given?
+  end
+
+  private
+
+  def extract_image_url(html)
+    return nil if html.blank?
+    doc = Nokogiri::HTML(html)
+    img = doc.css("img").find { |el| el["src"].to_s.match?(/\.(png|jpe?g|gif|webp|svg)(\?|$)/i) }
+    return nil unless img
+    src = img["src"]
+    return src if src.start_with?("http://", "https://")
+    "#{ENV.fetch('WA_SITE_URL', '').chomp('/')}#{src}"
   end
 end

--- a/app/views/api/digital_sign/events.json.jbuilder
+++ b/app/views/api/digital_sign/events.json.jbuilder
@@ -2,12 +2,7 @@ json.generated_at Time.current
 
 json.events @events do |event|
   json.uid event.uid
-  # Use your actual columns here
-  #json.title (event.respond_to?(:title) ? event.title : event.try(:name))
   json.start_date event.start_date
-  #json.location
-
-  #json.event_type
   json.registrations_limit event.registrations_limit
   json.pending_registrations_count event.pending_registrations_count
   json.confirmed_registrations_count event.confirmed_registrations_count
@@ -15,17 +10,16 @@ json.events @events do |event|
   json.name event.name
   json.event_type event.event_type
   json.location event.location
-
+  json.tags event.tags || []
+  json.image_url event.image_url
 
   json.active_registrations event.active_registrations do |reg|
     json.registration_type reg.registration_type
     json.registered_at reg.registration_date
   end
 
-
   json.updated_at event.updated_at
 end
-
 
 json.meta do
   json.page        @events.current_page
@@ -45,11 +39,3 @@ json.links do
     @events.prev_page ? url_for(request.query_parameters.merge(page: @events.prev_page)) : nil
   )
 end
-
-json.events do
-  json.array! @events do |e|
-    json.extract! e, :id, :event_type, :created_at
-    # add whatever else you want here
-  end
-end
-

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -61,6 +61,9 @@
         <li class="list-group-item">
           <%= link_to "Instructor Formbot", formbot_url(@event) %>
         </li>
+        <li class="list-group-item">
+          <%= link_to "Add to Google Calendar", google_calendar_url(@event), target: "_blank", rel: "noopener" %>
+        </li>
       </ul>
     </div>
     <% if current_user.signoffer? %>

--- a/db/migrate/20260522161330_add_tags_and_image_url_to_events.rb
+++ b/db/migrate/20260522161330_add_tags_and_image_url_to_events.rb
@@ -1,0 +1,6 @@
+class AddTagsAndImageUrlToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :tags, :text
+    add_column :events, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_23_154245) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_22_161330) do
   create_table "credentials", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider"
@@ -61,6 +61,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_23_154245) do
     t.integer "checked_in_attendees_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "tags"
+    t.string "image_url"
   end
 
   create_table "field_allowed_values", force: :cascade do |t|


### PR DESCRIPTION
Add tags and image_url to digital sign events API The digital signage team needs to filter and display events programmatically: tags tell them what to show, image_url gives them something to put on screen.

Tags come straight from the WA API's Tags field and are available in both the listing and detail endpoints.

Image URL is more roundabout: WA has no dedicated image field on events. Images live inside the DescriptionHtml as relative paths (e.g. /resources/Pictures/Electronics/foo.png). We parse the first <img> with a known image extension out of the HTML and prefix it with WA_SITE_URL to make it absolute. This field is only populated when syncing from the detail endpoint (webhooks), so it will be nil for events that haven't been touched since this deploy. A backfill task can address that if needed.